### PR TITLE
ENH: Add Linux aarch64, ppc64le, and macOS arm64 builds

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -12,6 +12,14 @@ jobs:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_aarch64_:
+        CONFIG: linux_aarch64_
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_ppc64le_:
+        CONFIG: linux_ppc64le_
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
   timeoutInMinutes: 360
   variables: {}
 

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -11,6 +11,9 @@ jobs:
       osx_64_:
         CONFIG: osx_64_
         UPLOAD_PACKAGES: 'True'
+      osx_arm64_:
+        CONFIG: osx_arm64_
+        UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
   variables: {}
 

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -1,0 +1,14 @@
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+target_platform:
+- linux-aarch64

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -1,0 +1,14 @@
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+target_platform:
+- linux-ppc64le

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -1,0 +1,16 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+macos_machine:
+- arm64-apple-darwin20.0.0
+target_platform:
+- osx-arm64

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -31,11 +31,21 @@ pkgs_dirs:
 solver: libmamba
 
 CONDARC
-mv /opt/conda/conda-meta/history /opt/conda/conda-meta/history.$(date +%Y-%m-%d-%H-%M-%S)
-echo > /opt/conda/conda-meta/history
-micromamba install --root-prefix ~/.conda --prefix /opt/conda \
-    --yes --override-channels --channel conda-forge --strict-channel-priority \
-    pip  rattler-build conda-forge-ci-setup=4 "conda-build>=24.1"
+curl -fsSL https://pixi.sh/install.sh | bash
+export PATH="~/.pixi/bin:$PATH"
+pushd "${FEEDSTOCK_ROOT}"
+arch=$(uname -m)
+if [[ "$arch" == "x86_64" ]]; then
+  arch="64"
+fi
+sed -i.bak -e "s/platforms = .*/platforms = [\"linux-${arch}\"]/" -e "s/# __PLATFORM_SPECIFIC_ENV__ =/docker-build-linux-$arch =/" pixi.toml
+echo "Creating environment"
+PIXI_CACHE_DIR=/opt/conda pixi install --environment docker-build-linux-$arch
+pixi list
+echo "Activating environment"
+eval "$(pixi shell-hook --environment docker-build-linux-$arch)"
+mv pixi.toml.bak pixi.toml
+popd
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 # set up the condarc
@@ -48,6 +58,9 @@ source run_conda_forge_build_setup
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
+if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]] && [[ "${HOST_PLATFORM}" != linux-* ]] && [[ "${BUILD_WITH_CONDA_DEBUG:-0}" != 1 ]]; then
+    EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --test skip"
+fi
 
 
 ( endgroup "Configuring conda" ) 2> /dev/null

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -9,34 +9,24 @@ set -xe
 MINIFORGE_HOME="${MINIFORGE_HOME:-${HOME}/miniforge3}"
 MINIFORGE_HOME="${MINIFORGE_HOME%/}" # remove trailing slash
 export CONDA_BLD_PATH="${CONDA_BLD_PATH:-${MINIFORGE_HOME}/conda-bld}"
-
-( startgroup "Provisioning base env with micromamba" ) 2> /dev/null
-MICROMAMBA_VERSION="1.5.10-0"
-if [[ "$(uname -m)" == "arm64" ]]; then
-  osx_arch="osx-arm64"
-else
-  osx_arch="osx-64"
+( startgroup "Provisioning base env with pixi" ) 2> /dev/null
+mkdir -p "${MINIFORGE_HOME}"
+curl -fsSL https://pixi.sh/install.sh | bash
+export PATH="~/.pixi/bin:$PATH"
+arch=$(uname -m)
+if [[ "$arch" == "x86_64" ]]; then
+  arch="64"
 fi
-MICROMAMBA_URL="https://github.com/mamba-org/micromamba-releases/releases/download/${MICROMAMBA_VERSION}/micromamba-${osx_arch}"
-MAMBA_ROOT_PREFIX="${MINIFORGE_HOME}-micromamba-$(date +%s)"
-echo "Downloading micromamba ${MICROMAMBA_VERSION}"
-micromamba_exe="$(mktemp -d)/micromamba"
-curl -L -o "${micromamba_exe}" "${MICROMAMBA_URL}"
-chmod +x "${micromamba_exe}"
+sed -i.bak "s/platforms = .*/platforms = [\"osx-${arch}\"]/" pixi.toml
 echo "Creating environment"
-"${micromamba_exe}" create --yes --root-prefix "${MAMBA_ROOT_PREFIX}" --prefix "${MINIFORGE_HOME}" \
-  --channel conda-forge \
-  pip rattler-build conda-forge-ci-setup=4 "conda-build>=24.1"
-echo "Moving pkgs cache from ${MAMBA_ROOT_PREFIX} to ${MINIFORGE_HOME}"
-mv "${MAMBA_ROOT_PREFIX}/pkgs" "${MINIFORGE_HOME}"
-echo "Cleaning up micromamba"
-rm -rf "${MAMBA_ROOT_PREFIX}" "${micromamba_exe}" || true
-( endgroup "Provisioning base env with micromamba" ) 2> /dev/null
+pixi install
+pixi list
+echo "Activating environment"
+eval "$(pixi shell-hook)"
+mv pixi.toml.bak pixi.toml
+( endgroup "Provisioning base env with pixi" ) 2> /dev/null
 
 ( startgroup "Configuring conda" ) 2> /dev/null
-echo "Activating environment"
-source "${MINIFORGE_HOME}/etc/profile.d/conda.sh"
-conda activate base
 export CONDA_SOLVER="libmamba"
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
@@ -77,6 +67,10 @@ fi
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     echo "rattler-build does not currently support debug mode"
 else
+
+    if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
+        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --test skip"
+    fi
 
     rattler-build build --recipe ./recipe \
         -m ./.ci_support/${CONFIG}.yaml \

--- a/README.md
+++ b/README.md
@@ -40,10 +40,31 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_aarch64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26008&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/brev-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26008&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/brev-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>osx_64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26008&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/brev-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26008&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/brev-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_" alt="variant">
                 </a>
               </td>
             </tr>

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,7 +1,16 @@
 conda_build_tool: rattler-build
-github:
-  branch_name: main
-  tooling_branch_name: main
+conda_install_tool: pixi
+build_platform:
+  linux_aarch64: linux_64
+  linux_ppc64le: linux_64
+  osx_arm64: osx_64
 conda_build:
   error_overlinking: true
 conda_forge_output_validation: true
+github:
+  branch_name: main
+  tooling_branch_name: main
+provider:
+  linux_aarch64: default
+  linux_ppc64le: default
+test: native_and_emulated

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,0 +1,77 @@
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+# -*- mode: toml -*-
+
+#                             VVVVVV  minimum `pixi` version
+"$schema" = "https://pixi.sh/v0.36.0/schema/manifest/schema.json"
+
+[project]
+name = "brev-feedstock"
+version = "3.50.1"  # conda-smithy version used to generate this file
+description = "Pixi configuration for conda-forge/brev-feedstock"
+authors = ["@conda-forge/brev"]
+channels = ["conda-forge"]
+platforms = ["linux-64", "linux-aarch64", "linux-ppc64le", "osx-64", "win-64"]
+
+[dependencies]
+conda-build = ">=24.1"
+conda-forge-ci-setup = "4.*"
+rattler-build = "*"
+
+[tasks]
+[tasks.inspect-all]
+cmd = "inspect_artifacts --all-packages"
+description = "List contents of all packages found in rattler-build build directory."
+[tasks.build]
+cmd = "rattler-build build --recipe recipe"
+description = "Build brev-feedstock directly (without setup scripts), no particular variant specified"
+[tasks."build-linux_64_"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_64_.yaml"
+description = "Build brev-feedstock with variant linux_64_ directly (without setup scripts)"
+[tasks."inspect-linux_64_"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_.yaml"
+description = "List contents of brev-feedstock packages built for variant linux_64_"
+[tasks."build-linux_aarch64_"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_aarch64_.yaml"
+description = "Build brev-feedstock with variant linux_aarch64_ directly (without setup scripts)"
+[tasks."inspect-linux_aarch64_"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_aarch64_.yaml"
+description = "List contents of brev-feedstock packages built for variant linux_aarch64_"
+[tasks."build-linux_ppc64le_"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_ppc64le_.yaml"
+description = "Build brev-feedstock with variant linux_ppc64le_ directly (without setup scripts)"
+[tasks."inspect-linux_ppc64le_"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_ppc64le_.yaml"
+description = "List contents of brev-feedstock packages built for variant linux_ppc64le_"
+[tasks."build-osx_64_"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/osx_64_.yaml"
+description = "Build brev-feedstock with variant osx_64_ directly (without setup scripts)"
+[tasks."inspect-osx_64_"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_64_.yaml"
+description = "List contents of brev-feedstock packages built for variant osx_64_"
+[tasks."build-osx_arm64_"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/osx_arm64_.yaml"
+description = "Build brev-feedstock with variant osx_arm64_ directly (without setup scripts)"
+[tasks."inspect-osx_arm64_"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_arm64_.yaml"
+description = "List contents of brev-feedstock packages built for variant osx_arm64_"
+
+[feature.smithy.dependencies]
+conda-smithy = "*"
+[feature.smithy.tasks.build-locally]
+cmd = "python ./build-locally.py"
+description = "Build packages locally using the same setup scripts used in conda-forge's CI"
+[feature.smithy.tasks.smithy]
+cmd = "conda-smithy"
+description = "Run conda-smithy. Pass necessary arguments."
+[feature.smithy.tasks.rerender]
+cmd = "conda-smithy rerender"
+description = "Rerender the feedstock."
+[feature.smithy.tasks.lint]
+cmd = "conda-smithy lint --conda-forge recipe"
+description = "Lint the feedstock recipe"
+
+[environments]
+smithy = ["smithy"]
+# This is a copy of default, to be enabled by build_steps.sh during Docker builds
+# __PLATFORM_SPECIFIC_ENV__ = []

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -16,16 +16,25 @@ build:
     - win
   script:
     - go-licenses save --save_path $SRC_DIR/library_licenses .
-    - go build -ldflags="-s -w -X github.com/brevdev/brev-cli/brev-cli.Version=${{ version }}" -v -o $PREFIX/bin/brev
-    # Install bash, zsh, and fish completions
-    - if: unix and target_platform == build_platform
+    - GOOS="${GOOS}" GOARCH="${GOARCH}" go build -ldflags="-s -w -X github.com/brevdev/brev-cli/brev-cli.Version=${{ version }}" -v -o ${PREFIX}/bin/brev
+    # Default to no cross-compile
+    - export BREV="${PREFIX}/bin/brev"
+    - if: unix and target_platform != build_platform
       then:
-        - mkdir -p $PREFIX/share/bash-completion/completions
-        - brev completion bash > $PREFIX/share/bash-completion/completions/brev
-        - mkdir -p $PREFIX/share/zsh/site-functions
-        - brev completion zsh > $PREFIX/share/zsh/site-functions/_brev
-        - mkdir -p $PREFIX/share/fish/vendor_completions.d
-        - brev completion fish > $PREFIX/share/fish/vendor_completions.d/brev.fish
+        # Need to compile for the build_platform arch
+        - if: build_platform == "linux-64" or build_platform == "osx-64"
+          # Fail if build_platform changes in future to non-x86_64 arch
+          then: export GOARCH=amd64
+        - GOOS="${GOOS}" GOARCH="${GOARCH}" go build -ldflags="-s -w -X github.com/brevdev/brev-cli/brev-cli.Version=${{ version }}" -v -o ${BUILD_PREFIX}/bin/brev
+        - export BREV="${BUILD_PREFIX}/bin/brev"
+
+    # Install bash, zsh, and fish completions
+    - mkdir -p ${PREFIX}/share/bash-completion/completions
+    - ${BREV} completion bash > ${PREFIX}/share/bash-completion/completions/brev
+    - mkdir -p ${PREFIX}/share/zsh/site-functions
+    - ${BREV} completion zsh > ${PREFIX}/share/zsh/site-functions/_brev
+    - mkdir -p ${PREFIX}/share/fish/vendor_completions.d
+    - ${BREV} completion fish > ${PREFIX}/share/fish/vendor_completions.d/brev.fish
 
 requirements:
   build:
@@ -34,9 +43,18 @@ requirements:
     - go-licenses
 
 tests:
+  - package_contents:
+      strict: true
+      files:
+        - bin/brev
+        - share/bash-completion/completions/brev
+        - share/zsh/site-functions/_brev
+        - share/fish/vendor_completions.d/brev.fish
+
   - script:
       - brev --version
       - brev --help
+
 about:
   homepage: https://developer.nvidia.com/brev
   summary: 'Brev CLI'

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -63,7 +63,8 @@ about:
   license: MIT
   license_file:
     - LICENSE
-    - library_licenses/**/**/LICENSE
+    - library_licenses/**/**/LICENSE*
+    - library_licenses/**/**/NOTICE*
   documentation: https://docs.nvidia.com/brev/latest/getting-started.html
   repository: https://github.com/brevdev/brev-cli
 

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -11,19 +11,21 @@ source:
   sha256: d7d8a58878c037372022f0c1d8fa58e15eb3d198498b521332d05def84cff351
 
 build:
-  number: 0
+  number: 1
   skip:
     - win
   script:
     - go-licenses save --save_path $SRC_DIR/library_licenses .
     - go build -ldflags="-s -w -X github.com/brevdev/brev-cli/brev-cli.Version=${{ version }}" -v -o $PREFIX/bin/brev
-    # Install bash, zsh, and fish completions 
-    - mkdir -p $PREFIX/share/bash-completion/completions
-    - brev completion bash > $PREFIX/share/bash-completion/completions/brev
-    - mkdir -p $PREFIX/share/zsh/site-functions
-    - brev completion zsh > $PREFIX/share/zsh/site-functions/_brev
-    - mkdir -p $PREFIX/share/fish/vendor_completions.d
-    - brev completion fish > $PREFIX/share/fish/vendor_completions.d/brev.fish
+    # Install bash, zsh, and fish completions
+    - if: unix and target_platform == build_platform
+      then:
+        - mkdir -p $PREFIX/share/bash-completion/completions
+        - brev completion bash > $PREFIX/share/bash-completion/completions/brev
+        - mkdir -p $PREFIX/share/zsh/site-functions
+        - brev completion zsh > $PREFIX/share/zsh/site-functions/_brev
+        - mkdir -p $PREFIX/share/fish/vendor_completions.d
+        - brev completion fish > $PREFIX/share/fish/vendor_completions.d/brev.fish
 
 requirements:
   build:
@@ -34,13 +36,14 @@ requirements:
 tests:
   - script:
       - brev --version
+      - brev --help
 about:
   homepage: https://developer.nvidia.com/brev
   summary: 'Brev CLI'
   description: |
     CLI tool for managing workspaces provided by brev.dev
   license: MIT
-  license_file: 
+  license_file:
     - LICENSE
     - library_licenses/**/**/LICENSE
   documentation: https://docs.nvidia.com/brev/latest/getting-started.html


### PR DESCRIPTION
* Enable builds for platforms: `linux-aarch64`, `linux-ppc64le`, `osx-arm64`.
* Guard completions to be same platform.
   - Avoid `Bad CPU type in executable` in `osx-arm64`.
* Bump build number.
* Generate shell completions for cross-compile builds.
   - For cross-compiles build `brev` for the `build_platform` arch and place under `$BUILD_PREFIX`, where you would place a host-targeted `brev`.
   - For platform needed, export the needed `brev` (`$PREFIX/bin/brev` for no cross-compile, `${BUILD_PREFIX}/bin/brev` for cross-compile) as an environmental variable to use for the rest of the build.
   - Add package content tests to ensure that completions exist.
* Needed for https://github.com/matthewfeickert-talks/reproducible-ml-for-scientists-with-pixi-scipy-2025/issues/7

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
