### PR TITLE
MNT: Use correct API for setting version

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -11,12 +11,12 @@ source:
   sha256: 265ef0698aa8d6b9fd7311b5aa16e2e0a2274dd4a2f3f01f1a035250825b8724
 
 build:
-  number: 0
+  number: 1
   skip:
     - win
   script:
     - go-licenses save --save_path $SRC_DIR/library_licenses .
-    - GOOS="${GOOS}" GOARCH="${GOARCH}" go build -ldflags="-s -w -X github.com/brevdev/brev-cli/brev-cli.Version=${{ version }}" -v -o ${PREFIX}/bin/brev
+    - GOOS="${GOOS}" GOARCH="${GOARCH}" go build -ldflags="-s -w -X github.com/brevdev/brev-cli/pkg/cmd/version.Version=${{ version }}" -v -o ${PREFIX}/bin/brev
     # Default to no cross-compile
     - export BREV="${PREFIX}/bin/brev"
     - if: unix and target_platform != build_platform
@@ -25,7 +25,7 @@ build:
         - if: build_platform == "linux-64" or build_platform == "osx-64"
           # Fail if build_platform changes in future to non-x86_64 arch
           then: export GOARCH=amd64
-        - GOOS="${GOOS}" GOARCH="${GOARCH}" go build -ldflags="-s -w -X github.com/brevdev/brev-cli/brev-cli.Version=${{ version }}" -v -o ${BUILD_PREFIX}/bin/brev
+        - GOOS="${GOOS}" GOARCH="${GOARCH}" go build -ldflags="-s -w -X github.com/brevdev/brev-cli/pkg/cmd/version.Version=${{ version }}" -v -o ${BUILD_PREFIX}/bin/brev
         - export BREV="${BUILD_PREFIX}/bin/brev"
 
     # Install bash, zsh, and fish completions

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -16,7 +16,7 @@ build:
     - win
   script:
     - go-licenses save --save_path $SRC_DIR/library_licenses .
-    - GOOS="${GOOS}" GOARCH="${GOARCH}" go build -ldflags="-s -w -X github.com/brevdev/brev-cli/pkg/cmd/version.Version=${{ version }}" -v -o ${PREFIX}/bin/brev
+    - GOOS="${GOOS}" GOARCH="${GOARCH}" go build -ldflags="-s -w -X github.com/brevdev/brev-cli/pkg/cmd/version.Version=v${{ version }}" -v -o ${PREFIX}/bin/brev
     # Default to no cross-compile
     - export BREV="${PREFIX}/bin/brev"
     - if: unix and target_platform != build_platform
@@ -25,7 +25,7 @@ build:
         - if: build_platform == "linux-64" or build_platform == "osx-64"
           # Fail if build_platform changes in future to non-x86_64 arch
           then: export GOARCH=amd64
-        - GOOS="${GOOS}" GOARCH="${GOARCH}" go build -ldflags="-s -w -X github.com/brevdev/brev-cli/pkg/cmd/version.Version=${{ version }}" -v -o ${BUILD_PREFIX}/bin/brev
+        - GOOS="${GOOS}" GOARCH="${GOARCH}" go build -ldflags="-s -w -X github.com/brevdev/brev-cli/pkg/cmd/version.Version=v${{ version }}" -v -o ${BUILD_PREFIX}/bin/brev
         - export BREV="${BUILD_PREFIX}/bin/brev"
 
     # Install bash, zsh, and fish completions


### PR DESCRIPTION
Resolves https://github.com/conda-forge/brev-feedstock/issues/6

* Use `github.com/brevdev/brev-cli/pkg/cmd/version.Version` to set the version.
   - Use 'v' prefix on version number to ensure string matching.
* Bump build number.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
